### PR TITLE
Continuous JSON parsing [experimental]

### DIFF
--- a/raven_back/test/integration/client.dart
+++ b/raven_back/test/integration/client.dart
@@ -10,14 +10,15 @@ void main() {
         // RavenElectrumClient(await connect('testnet.rvn.rocks'));
         RavenElectrumClient(await connect('rvn4lyfe.com', port: 50003));
     var txHash = [
-      //'6b082294f4046c05d54e7fa4c846673258c1cb63734f50558b9210b75e3037d5',
+      '6b082294f4046c05d54e7fa4c846673258c1cb63734f50558b9210b75e3037d5',
       '5cdde1dc17f820320011ec648272237322e1cde48e62158b3cb56999c5aba0e8',
-      //'9b64eb258a4352a68c4ce98cbbadddcbbcb285c422f7f9f97ed4b826d0a387d7',
+      '9b64eb258a4352a68c4ce98cbbadddcbbcb285c422f7f9f97ed4b826d0a387d7',
     ];
     var tx = await client.getTransaction(txHash[0]);
     //print(tx);
-    print('done');
-    //var tx1 = await client.getTransaction(txHash[1]);
+    var tx1 = await client.getTransaction(txHash[1]);
+    print(tx1);
+    var tx2 = await client.getTransaction(txHash[2]);
     //print(tx1);
   });
 }

--- a/raven_electrum/lib/client/json_newline_transformer.dart
+++ b/raven_electrum/lib/client/json_newline_transformer.dart
@@ -4,49 +4,30 @@ import 'package:async/async.dart';
 
 import 'package:stream_channel/stream_channel.dart';
 
+import 'package:json_stream_parser/json_stream_parser.dart';
+
 /// A [StreamChannelTransformer] similar to the default jsonDocument
 /// transformer that is built in to stream_channel, but adds a newline
 /// at the end of the JSON document, per Electrum's RPC requirement.
-final StreamChannelTransformer<Object?, String> jsonNewlineDocument =
-    _JsonNewlineTransformer();
+final StreamChannelTransformer<Object?, String> jsonNewlineDocument = const _JsonNewlineTransformer();
 
-class _JsonNewlineTransformer
-    implements StreamChannelTransformer<Object?, String> {
-  String inCache = "";
-  int bracketCount = 0;
-
-  dynamic parseInAndMaybeReturn(String data) {
-    for (var rune in data.runes) {
-      var character = String.fromCharCode(rune);
-      if (character == '{') {
-        bracketCount += 1;
-      } else if (character == '}') {
-        bracketCount -= 1;
-      }
-    }
-    inCache += data;
-    if (bracketCount == 0) {
-      var ret = jsonDecode(inCache);
-      inCache = '';
-      return ret;
-    }
-  }
-
-  _JsonNewlineTransformer();
-
+class _JsonNewlineTransformer implements StreamChannelTransformer<Object?, String> {
+  const _JsonNewlineTransformer();
+  
   @override
   StreamChannel<Object?> bind(StreamChannel<String> channel) {
-    var stream = channel.stream.map(parseInAndMaybeReturn);
+    var stream = channel.stream.transform(ContinuousJsonDecoder());
     var sink = StreamSinkTransformer<Object, String>.fromHandlers(
-        handleData: (data, sink) {
-      if ((data as Map).containsKey('error')) {
-        /// todo: fix lower layers so this never happens.
-        print('ERROR @ '
+      handleData: (data, sink) {
+        if ((data as Map).containsKey('error')) {
+          /// todo: fix lower layers so this never happens.
+          print('ERROR @ '
             'raven_electrum.lib.client.json_newline_transformer.dart: $data');
-      } else {
-        sink.add(jsonEncode(data) + '\n');
+        } else {
+          sink.add(jsonEncode(data) + '\n');
+        }
       }
-    }).bind(channel.sink);
+    ).bind(channel.sink);
     return StreamChannel.withCloseGuarantee(stream, sink);
   }
 }

--- a/raven_electrum/pubspec.yaml
+++ b/raven_electrum/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   pedantic: ^1.10.0
   stream_channel: ^2.1.0
   stack_trace: ^1.10.0
+  json_stream_parser:
+    git: https://github.com/kralverde/dart-json-stream-decoder.git
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
The internal JsonDecoder stream transformer is only valid for 1 JSON object before the stream must be closed. In order to continuously return JSON objects on an effectively endless stream, this PR uses a custom dart package that is an exact copy of dart's internal JsonDecoder stream transformer (that does not implement any UTF8 Streams) except that JSON objects are returned every JSON STATE_END instead of on the stream closure.